### PR TITLE
Update .gitignore to ignore /obj and /bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,6 +221,10 @@ project.lock.json
 # UWP Projects
 AppPackages/
 
+# Ignore any files in /bin and /obj Folders
+**/bin/*
+**/obj/*
+
 #####
 # End of core ignore list, below put you custom 'per project' settings (patterns or path)
 #####


### PR DESCRIPTION
+ /obj and /bin are superfluous file directory created by the IDE for compiling and linking C# files